### PR TITLE
Use add-ignore with pep257 setup.cfg entry

### DIFF
--- a/examples/setup.cfg
+++ b/examples/setup.cfg
@@ -6,7 +6,7 @@ show-source = true
 exclude = */migrations/*,docs/*,env/*
 
 [pep257]
-ignore = D203
+add-ignore =
 
 [coverage:run]
 source = .


### PR DESCRIPTION
This will pick up / use new defaults on-the-fly, e.g. as with D203 being
replaced by D211 (https://github.com/GreenSteam/pep257/pull/137).
