### PR TITLE
Adds `dcc` executable to simplify cloning and contributing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: python
+sudo: false
+cache:
+  - pip
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "pypy"
+  - "pypy3"
+install:
+  - pip install --upgrade pip
+  - pip install -r requirements-dev.txt
+script:
+  - isort --check-only --recursive --diff .
+  - flake8 --jobs=2 .
+  - pep257 --verbose --explain --source --count
+after_success:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -25,6 +25,51 @@ The contribution guide is the central part of the projects. All tools and exampl
 ## Tools
 The tool belt consists of a set of tools and configuration files that ensure contributions to be aligned with the contribution guide.
 
+### DCC
+Wo make things even easier we cooked up a little tool for you called `dcc`.
+It will set you up with just one simple command, so you can focus on implementing
+that feature you've been thining about.
+
+To get started just install `dcc` globally.
+
+```bash
+pip install dcc
+```
+
+If you want to get started to contribute to any package supporting Django Contributing Commons:
+
+```
+usage: dcc [-h] [-v] PACKAGE
+
+positional arguments:
+  PACKAGE     name of the pypi package
+
+optional arguments:
+  -h, --help  show this help message and exit
+  -v          verbose mode (default: off)
+```
+
+So if you want to write a feature for django-select2, just type:
+```bash
+$ dcc django-select2
+```
+
+#### DCC for maintainers
+Supporting DCC is easy, all you need to do is set the `download_url` to you Github repository in your `setup.py` file.
+
+e.g.
+```python
+setup(
+    name='dcc',
+    
+    download_url='https://github.com/codingjoe/django-cc',
+    
+    packages=find_packages(),
+)
+```
+
+Make sure to put all your development requirements in the `requirements-dev.txt` file.
+
 ### [EditorConfig]
 EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs. [[1]][EditorConfig]
 

--- a/dcc/__init__.py
+++ b/dcc/__init__.py
@@ -1,0 +1,51 @@
+"""
+Django Contributing Commons.
+
+Django-CC makes contributing to PyPI packages a breeze.
+It will download the package source code and sets you up
+so you can focus on developing amazing new features.
+"""
+from distutils.spawn import find_executable
+
+import os
+
+VERSION = (0, 1, 0)
+
+__version__ = '.'.join(str(i) for i in VERSION)
+__author__ = 'Johannes Hoppe'
+__licence__ = """This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org>"""
+
+HUB = find_executable('hub')
+PIP = find_executable('pip')
+VIRTUALENV = find_executable('virtualenv')
+SOURCE = find_executable('source')
+BASE_DIR = os.path.dirname(os.path.realpath(__file__))
+
+
+class DjangoCCError(Exception):
+    """dcc runtime error."""
+
+    pass

--- a/dcc/__main__.py
+++ b/dcc/__main__.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+"""The main entry point. Invoke as ``dcc`` or ``python -m dcc``."""
+import argparse
+import logging
+import os
+import sys
+
+from . import HUB, __doc__ as description
+from .utils import get_github_url, setup_env, setup_git, target_path_exists
+
+logger = logging.getLogger('dcc')
+
+
+def check_binaries():
+    """Test if ``hub`` is installed."""
+    if not HUB:
+        raise RuntimeError(
+                '"hub" was not found.\n'
+                'Please download hup at https://hub.github.com/'
+        )
+
+PROGRESS_MSG = "One {package_name}, coming right up!\n..."
+
+
+SUCCESS_MSG = """
+{package_name} has been forked and copied to:
+{target_path}
+
+To get started create a new feature branch using:
+hub branch -d my_feature
+
+Once you're done commit and push...
+hub push --set-upstream {username} my_feature
+
+...and create a pull-request:
+hub pull-request -b {owner_name}
+"""
+
+
+def get_args():
+    """Setup argument parser and return parsed arguments."""
+    parser = argparse.ArgumentParser(
+            description=description.strip()
+    )
+    parser.add_argument('package_name', metavar='PACKAGE', type=str,
+                        help='Name of the PyPI package.')
+    parser.add_argument('-v', dest='verbose', action='store_const',
+                        const=logging.DEBUG, default=logging.WARNING,
+                        help='verbose mode (default: off)')
+    return parser.parse_args()
+
+
+def main():
+    """Main method that is invoked by ``dcc``."""
+    args = get_args()
+    package_name = args.package_name
+    if target_path_exists(package_name):
+        return
+    print(PROGRESS_MSG.format(package_name=package_name))
+
+    handler = logging.StreamHandler()
+    logger.addHandler(handler)
+    logger.setLevel(args.verbose)
+
+    check_binaries()
+    github_url = get_github_url(package_name)
+    repo_name, username, owner_name = setup_git(args.package_name, github_url)
+    setup_env(repo_name)
+    msg = SUCCESS_MSG.format(
+        package_name=package_name,
+        target_path=os.path.join(os.getcwd(), package_name),
+        username=username,
+        owner_name=owner_name,
+    )
+    print(msg)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/dcc/git_commit_msg.txt
+++ b/dcc/git_commit_msg.txt
@@ -1,0 +1,6 @@
+# (feat, fix, docs, style, refactor, pref, test, chore): <subject>
+
+# <body>
+
+
+# <footer>

--- a/dcc/utils.py
+++ b/dcc/utils.py
@@ -1,0 +1,126 @@
+"""``dcc`` utils."""
+import json
+import logging
+import os
+import subprocess
+import sys
+
+from . import BASE_DIR, HUB, PIP, VIRTUALENV, DjangoCCError
+
+PY3 = sys.version_info[0] == 3
+if PY3:
+    from urllib.request import urlopen
+else:
+    from urllib import urlopen
+
+
+logger = logging.getLogger('dcc')
+
+
+PYPI_JSON_URL = "https://pypi.python.org/pypi/{package_name}/json"
+GITHUB_URL = "https://github.com/{username}/{repo_name}.git"
+
+
+def get_github_url(package_name):
+    """Return Github url based on PYPI package information."""
+    url = PYPI_JSON_URL.format(package_name=package_name)
+    response = urlopen(url)
+    if response.code == 404:
+        raise DjangoCCError('The package "%s" does not exist.' % package_name)
+    if PY3:
+        body = response.read().decode('utf-8')
+    else:
+        body = response.read()
+    data = json.loads(body)
+    github_url = data['info']['download_url']
+    if not github_url.startswith('https://github.com/'):
+        raise DjangoCCError('The package "%s" does not support Django-CC.' % package_name)
+    return github_url
+
+
+def parse_github_url(url):
+    """Return username and repository name base on Github url."""
+    return [x for x in url.rsplit('/') if x][-2:]
+
+
+def setup_git(package_name, github_url):
+    """Clone git repository and setup own Github fork and remote."""
+    owner_name, repo_name = parse_github_url(github_url)
+    git_clone(owner_name, repo_name)
+    username = get_github_username()
+    try:
+        logger.info("Forking...")
+        logger.debug(
+                subprocess.check_output([HUB, 'fork'], stderr=subprocess.STDOUT, cwd=repo_name)
+        )
+    except subprocess.CalledProcessError:
+        logger.info("Fork already exists. Adding remote...")
+        if username != owner_name:
+            add_git_remote(username, repo_name)
+        else:
+            logger.info("%s is your own package. No remote added." % package_name)
+    set_git_commit_msg(repo_name)
+    return repo_name, username, owner_name
+
+
+def git_clone(owner_name, repo_name):
+    github_url = GITHUB_URL.format(username=owner_name, repo_name=repo_name)
+    logger.info("Cloning %s" % github_url)
+    output = subprocess.check_output(
+            [HUB, 'clone', '-p', '-o', owner_name,
+             '{}/{}'.format(owner_name, repo_name), repo_name],
+            stderr=subprocess.STDOUT,
+    )
+    logger.debug(output)
+
+
+def add_git_remote(username, repo_name):
+    """Add git remote based on username."""
+    logger.debug(subprocess.check_output([HUB, 'remote', 'add', '-p', username], cwd=repo_name))
+
+
+def get_github_username():
+    """Return Github user name."""
+    output = subprocess.check_output([HUB, 'config', '--get', 'github.user'])
+    username = output.strip().decode('utf-8')
+    if not username:
+        raise DjangoCCError(
+                'You have not setup your Github username in your git config.\n'
+                'You may do so by executing:\n'
+                'git config --global github.user [YOUR_USERNAME]'
+        )
+    return username
+
+
+def set_git_commit_msg(repo_name):
+    """Set custom git commit message for given repository."""
+    template = os.path.join(BASE_DIR, 'git_commit_msg.txt')
+    output = subprocess.check_output(
+                    [HUB, 'config', 'commit.template', template],
+                    cwd=repo_name
+            )
+    logger.debug(output)
+
+
+def setup_env(repo_name):
+    """Set up virtual environment and install dependencies."""
+    print("Setting up virtualenv...")
+    logger.debug(subprocess.check_output([VIRTUALENV, 'env'], cwd=repo_name))
+    print("Installing requirements...")
+    logger.debug(subprocess.check_output(
+            ['env/bin/python', PIP, 'install', '-r', 'requirements-dev.txt'],
+            cwd=repo_name
+    ))
+
+
+TARGET_EXISTS_MSG = "Seems like you had one too many.\n{package_name} already exists."
+
+
+def target_path_exists(package_name):
+    """Test if target path is already existing."""
+    target_path = os.path.join(os.getcwd(), package_name)
+    if os.path.exists(target_path):
+        print(TARGET_EXISTS_MSG.format(package_name=package_name))
+        return True
+    else:
+        return False

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+flake8==2.5.0
+isort==4.2.2
+mccabe==0.3.1
+pep257==0.7.0
+pep8==1.6.2
+pep8-naming==0.3.3
+pre-commit==0.6.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,20 @@
+[flake8]
+max-line-length = 100
+max-complexity = 10
+statistics = true
+show-source = true
+exclude = env/*
+
+[pep257]
+match = (?!setup.py)
+match-dir = (?!env)
+
+[isort]
+atomic = true
+multi_line_output = 5
+line_length = 79
+combine_as_imports = true
+skip = wsgi.py,docs,env
+known_first_party = dcc
+known_standard_library = distutils
+default_section = THIRDPARTY

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,48 @@
+from distutils.spawn import find_executable
+
+from setuptools import find_packages, setup
+
+import dcc
+
+if not find_executable('hub'):
+    raise RuntimeError(
+        '"hub" was not found.\n'
+        'Please download hup at https://hub.github.com/'
+    )
+
+setup(
+    name='dcc',
+    version=dcc.__version__,
+    description=dcc.__doc__.strip(),
+    url='https://github.com/codingjoe/django-cc',
+    download_url='https://github.com/codingjoe/django-cc',
+    bugtrack_url='https://github.com/codingjoe/django-cc/issues',
+    author=dcc.__author__,
+    author_email='info@johanneshoppe.com',
+    license=dcc.__licence__,
+    packages=find_packages(),
+    entry_points={
+        'console_scripts': [
+            'dcc = dcc.__main__:main',
+            'django-cc = dcc.__main__:main',
+        ],
+    },
+    install_requires=[],
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Environment :: Console',
+        'Intended Audience :: Developers',
+        'License :: Public Domain',
+        'Topic :: Software Development',
+        'Topic :: Software Development :: Version Control',
+        'Topic :: Terminals',
+        'Topic :: Text Processing',
+        'Topic :: Utilities',
+    ],
+)


### PR DESCRIPTION
Adds not `dcc` command that can be invoked as follows:

```
dcc PYPI_PACKAGE
```

eg:

```
dcc django-stdimage
```

This will automatically clone and fork the repo, add a virtualenv
and install all requirements. It will also change the commit
message template for the new repository.
